### PR TITLE
Add armhf and arm64 Dockerfiles

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,16 @@
+# This Dockerfile uses Docker Multi-Stage Builds
+# See https://docs.docker.com/engine/userguide/eng-image/multistage-build/
+# Requires Docker v17.05
+
+# Base image
+FROM arm64v8/debian:stretch
+
+# Copy scripts from upstream sillelien/tutum-cron image
+COPY --from=sillelien/tutum-cron /*.sh /
+COPY --from=sillelien/tutum-cron /etc/services.d/cron/run/ /etc/services.d/cron/run/
+
+# Copy app
+COPY run.sh /
+
+# App command
+ENTRYPOINT [ "/run.sh" ]

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,0 +1,16 @@
+# This Dockerfile uses Docker Multi-Stage Builds
+# See https://docs.docker.com/engine/userguide/eng-image/multistage-build/
+# Requires Docker v17.05
+
+# Base image
+FROM arm32v7/debian:stretch
+
+# Copy scripts from upstream sillelien/tutum-cron image
+COPY --from=sillelien/tutum-cron /*.sh /
+COPY --from=sillelien/tutum-cron /etc/services.d/cron/run/ /etc/services.d/cron/run/
+
+# Copy app
+COPY run.sh /
+
+# App Command
+ENTRYPOINT [ "/run.sh" ]


### PR DESCRIPTION
Fixes #2 

Will build automatically on Dockerhub and produce arm images capable of running on a Raspberry Pi.

Dockerhub automated builds:
https://hub.docker.com/r/ecliptik/docker-cron-container-starter/builds/

Dockerhub images for armhf and arm64:
https://hub.docker.com/r/ecliptik/docker-cron-container-starter/tags/

Dockerhub Automated Build Settings
<img width="1263" alt="screen shot 2018-10-02 at 12 12 11 am" src="https://user-images.githubusercontent.com/1261742/46334175-eb3bb780-c5d7-11e8-83c3-b2d2c3815044.png">